### PR TITLE
Defer transfers until account balance becomes sufficient for transfers

### DIFF
--- a/src/edu/temple/cis/c3238/banksim/Account.java
+++ b/src/edu/temple/cis/c3238/banksim/Account.java
@@ -11,33 +11,42 @@ public class Account {
     private final int id;
     private final Bank myBank;
 
-    public Account(Bank myBank, int id, int initialBalance) {
+    Account(Bank myBank, int id, int initialBalance) {
         this.myBank = myBank;
         this.id = id;
         balance = initialBalance;
     }
 
-    public int getBalance() {
+    int getBalance() {
         return balance;
     }
 
-    public synchronized boolean withdraw(int amount) {
+    synchronized boolean withdraw(int amount) {
         if (amount <= balance) {
             int currentBalance = balance;
 //            Thread.yield(); // Try to force collision
-            int newBalance = currentBalance - amount;
-            balance = newBalance;
+            balance = currentBalance - amount;
             return true;
         } else {
             return false;
         }
     }
 
-    public synchronized void deposit(int amount) {
+    synchronized void deposit(int amount) {
         int currentBalance = balance;
 //        Thread.yield();   // Try to force collision
-        int newBalance = currentBalance + amount;
-        balance = newBalance;
+        balance = currentBalance + amount;
+        notifyAll();
+    }
+
+    synchronized void waitForAvailableFunds(int amount) {
+        while (amount >= balance && !myBank.isTesting()) {
+            try {
+                wait(300);
+            } catch (InterruptedException ex) {
+                /* ignore */
+            }
+        }
     }
     
     @Override

--- a/src/edu/temple/cis/c3238/banksim/Bank.java
+++ b/src/edu/temple/cis/c3238/banksim/Bank.java
@@ -15,6 +15,7 @@ class Bank {
     private long ntransacts;
     private final int initialBalance;
     private final int numAccounts;
+    private boolean testing;
     ReentrantLock bankLock;
 
     Bank(int numAccounts, int initialBalance) {
@@ -25,11 +26,12 @@ class Bank {
             accounts[i] = new Account(this, i, initialBalance);
         }
         ntransacts = 0;
+        testing = false;
         bankLock = new ReentrantLock();
     }
 
     void transfer(int from, int to, int amount) {
-//        accounts[from].waitForAvailableFunds(amount);
+        accounts[from].waitForAvailableFunds(amount);
         if (accounts[from].withdraw(amount)) {
             accounts[to].deposit(amount);
         }
@@ -45,10 +47,16 @@ class Bank {
     int size() {
         return accounts.length;
     }
-    
-    
+
     private boolean shouldTest() {
-        return ++ntransacts % NTEST == 0;
+        return (++ntransacts % NTEST == 0) && !testing;
     }
 
+    boolean isTesting() {
+        return testing;
+    }
+
+    void setTesting(boolean testing) {
+        this.testing = testing;
+    }
 }

--- a/src/edu/temple/cis/c3238/banksim/TestThread.java
+++ b/src/edu/temple/cis/c3238/banksim/TestThread.java
@@ -17,6 +17,7 @@ class TestThread implements Runnable {
     @Override
     public void run() {
         bank.bankLock.lock();
+        bank.setTesting(true);
         while (bank.bankLock.getQueueLength() < numAccounts) {
             try {
                 Thread.sleep(50);
@@ -41,6 +42,7 @@ class TestThread implements Runnable {
             System.out.println(Thread.currentThread().toString() +
                     " The bank is in balance");
         }
+        bank.setTesting(false);
         bank.bankLock.unlock();
     }
 }


### PR DESCRIPTION
The initial code does not allow an account to transfer out fund if the transferring amount is greater than the account balance. This implements a wait/notify solution to defer the transfer until funds are available in waitForAvailableFunds() method.

Waiting threads would just skip the transaction like they used to do if TestThread is waiting for them. Also, only one test can be initiated at a time (since there's no point for more than one test at a time.)